### PR TITLE
Don't overwrite system-exported CFLAGS in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ WARNING_OPTIONS =
 LANGUAGE_OPTIONS = 
 COMPILER_OPTIONS = -g 
 
-CFLAGS   = $(WARNING_OPTIONS) $(LANGUAGE_OPTIONS) $(COMPILER_OPTIONS)
+CFLAGS += $(WARNING_OPTIONS) $(LANGUAGE_OPTIONS) $(COMPILER_OPTIONS)
 
 ######################################################################
 


### PR DESCRIPTION
Don't overwrite system-exported CFLAGS in makefile, append to them instead. 

This way the makefile honors CFLAGS exported from the environment, which is required for building erlang-serial in Linux distribution packages.

Sample packaging for Debian that relies on this can be found at https://github.com/Shnatsel/erlang-serial