### PR TITLE
Explicitly add CREAD to c_cflag

### DIFF
--- a/c_src/serial.c
+++ b/c_src/serial.c
@@ -176,6 +176,7 @@ void set_raw_tty_mode(int fd)
   
   ttymodes.c_cflag |= CS8;         /* enable eight bit chars */
   ttymodes.c_cflag &= ~PARENB;     /* disable input parity check */
+  ttymodes.c_cflag |= CREAD;       /* enable receiver */
 
   ttymodes.c_oflag &= ~OPOST;      /* disable output processing */
 


### PR DESCRIPTION
CREAD flag is disabled after system boot for some tty devices.
This affects probably less than 1% of all devices.
For instance, this is a case for /dev/ttyS? managed by 8250_omap linux kernel driver.

The flag must be set if we want to read from the device, so lets set it explicitly even when it is already set.
